### PR TITLE
Feature: Edit Product Screen

### DIFF
--- a/frontend/inventory-frontend/src/components/ProductTable/ProductTable.tsx
+++ b/frontend/inventory-frontend/src/components/ProductTable/ProductTable.tsx
@@ -32,9 +32,9 @@ export function ProductTable({ products, onEdit, onDelete, onToggleStock }: Prop
         const date = new Date(exp)
         const diffDays = (date.getTime() - now.getTime()) / (1000 * 3600 * 24)
 
-        if (diffDays < 7) return '#ffe6e6'
-        if (diffDays < 14) return '#fff9c4'
-        return '#e8f5e9'
+        if (diffDays < 7) return '#ffe6e6' // red
+        if (diffDays < 14) return '#fff9c4' // yellow
+        return '#e8f5e9' // green
     }
 
     return (

--- a/frontend/inventory-frontend/src/pages/ProductListPage.tsx
+++ b/frontend/inventory-frontend/src/pages/ProductListPage.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useState } from 'react'
+
 import { ProductTable } from '../components/ProductTable/ProductTable'
-import type { Product } from '../types/product'
-import { deleteProduct, fetchPaginatedProducts } from '../services/productService'
 import ProductFilters from '../components/ProductFilters/ProductFilters'
+import ProductForm from '../components/ProductForm/ProductForm'
+
+import type { Product, PaginatedResponse } from '../types/product'
+import { deleteProduct, fetchPaginatedProducts, createProduct, updateProduct} from '../services/productService'
+
 import { Pagination, Stack } from '@mui/material'
 import { Container, Typography, Box } from '@mui/material'
 
@@ -12,6 +16,8 @@ export default function ProductListPage() {
     const [page, setPage] = useState(0)
     const [totalPages, setTotalPages] = useState(1)
     const [loading, setLoading] = useState(true)
+    const [dialogOpen, setDialogOpen] = useState(false)
+    const [selectedProduct, setSelectedProduct] = useState<Product | undefined>(undefined)
 
     function handleDelete(id: number) {
     if (!confirm('Are you sure you want to delete this item?')) return
@@ -30,6 +36,20 @@ export default function ProductListPage() {
                 alert('An error occurred while deleting the product')
             })
     }
+
+    const fetchProducts = async () => {
+        setLoading(true);
+        try {
+            const data = await fetchPaginatedProducts(page, 10);
+            setProducts(data.content);
+            setTotalPages(data.totalPages);
+        } catch (err) {
+            console.error(err);
+            alert("An error occurred while fetching products");
+        } finally {
+            setLoading(false);
+        }
+    };
 
     useEffect(() => {
         setLoading(true)
@@ -69,9 +89,34 @@ export default function ProductListPage() {
             />
             </Box>
 
+            <ProductForm
+                open={dialogOpen}
+                onClose={() => setDialogOpen(false)}
+                product={selectedProduct}
+                existingCategories={[...new Set(products.map(p => p.category))]}
+                onSave={async (updatedProduct) => {
+                    try {
+                    if (updatedProduct.id) {
+                        await updateProduct(updatedProduct.id, updatedProduct)
+                    } else {
+                        await createProduct(updatedProduct)
+                    }
+                    await fetchProducts()  // refresca la tabla si tienes esta función
+                    } catch (error) {
+                    console.error("Error saving product", error)
+                    } finally {
+                    setDialogOpen(false)
+                    }
+                }}
+            />
+
             <ProductTable
             products={products}
-            onEdit={(product) => alert(`Edit: ${product.name}`)}
+            onEdit={(product) => {
+                setSelectedProduct(product)
+                setDialogOpen(true)
+            }}
+
             onDelete={handleDelete}
             onToggleStock={(id, inStock) =>
                 alert(`Marcar ${id} como ${inStock ? 'en stock' : 'sin stock'}`)

--- a/frontend/inventory-frontend/src/types/product.ts
+++ b/frontend/inventory-frontend/src/types/product.ts
@@ -1,12 +1,12 @@
 export type Product = {
-    id: string
+    id: number
     name: string
     category: string
     unitPrice: number
     stockQuantity: number
     expirationDate?: string 
-    creationDate: string
-    lastUpdatedDate: string
+    creationDate?: string
+    lastUpdatedDate?: string
     outOfStock?: boolean 
 }
 


### PR DESCRIPTION
This PR implements the product editing feature as part of the `feature/edit-product-screen` branch.

### Changes Introduced:
- Added a modal screen (`ProductForm`) for editing existing products.
- Connected the form to backend API using `PUT /products/{id}`.
- Ensured form fields are pre-filled when editing.
- Added basic validations (e.g., expiration date cannot be in the past).

### How to Test:
1. Go to the product list view.
2. Click the "Edit" button on any product.
3. Modify the values in the modal form and save.
4. Confirm that changes are reflected and persisted in the backend.

### Notes:
- Frontend validations for the expiration date were added (can't select past dates).
- Backend must be running locally on `http://localhost:9090`.

### Related Issues / Tasks:
- Inventory Frontend — Product editing UI
- Inventory Backend — PUT endpoint

Please review and approve for merge into `main`.
