### PR TITLE
fix: toggle stock status from product table

### DIFF
--- a/frontend/inventory-frontend/src/components/ProductTable/ProductTable.tsx
+++ b/frontend/inventory-frontend/src/components/ProductTable/ProductTable.tsx
@@ -66,7 +66,7 @@ export function ProductTable({ products, onEdit, onDelete, onToggleStock }: Prop
                     <Checkbox
                         checked={isOutOfStock}
                         onChange={(e) =>
-                        onToggleStock(Number(p.id), !e.target.checked)
+                            onToggleStock(Number(p.id), e.target.checked)
                         }
                         inputProps={{ 'aria-label': 'Toggle stock status' }}
                     />

--- a/frontend/inventory-frontend/src/pages/ProductListPage.tsx
+++ b/frontend/inventory-frontend/src/pages/ProductListPage.tsx
@@ -42,6 +42,27 @@ export default function ProductListPage() {
             })
     }
 
+    const handleToggleStock = async (id: number, outOfStock: boolean) => {
+        const productToUpdate = products.find(p => p.id === id)
+        if (!productToUpdate) return
+
+        const updated = {
+            ...productToUpdate,
+            outOfStock,
+            stockQuantity: outOfStock ? 0 : 10
+        }
+
+        try {
+            await updateProduct(id, updated)
+            const data = await fetchPaginatedProducts(page, 10)
+            setProducts(data.content)
+            setTotalPages(data.totalPages)
+        } catch (err: any) {
+            alert(err.message || 'Error updating product stock status')
+        }
+    }
+
+
     const handleSave = async (productData: Product) => {
         try {
             if (productData.id) {
@@ -166,15 +187,13 @@ export default function ProductListPage() {
             />
 
             <ProductTable
-            products={products}
-            onEdit={(product) => {
-                setSelectedProduct(product)
-                setDialogOpen(true)
-            }}
-            onDelete={handleDelete}
-            onToggleStock={(id, inStock) =>
-                alert(`Marcar ${id} como ${inStock ? 'en stock' : 'sin stock'}`)
-            }
+                products={products}
+                onEdit={(product) => {
+                    setSelectedProduct(product)
+                    setDialogOpen(true)
+                }}
+                onDelete={handleDelete}
+                onToggleStock={handleToggleStock}
             />
             
             <Stack spacing={2} alignItems="center" mt={4}>


### PR DESCRIPTION
This PR fixes the out-of-stock toggle functionality from the product table.
When a user checks the product as out of stock, its quantity is set to 0.
When unchecked, it is restored with a default quantity of 10 units.
