### PR TITLE
Add clear filters button to product search section

### DIFF
--- a/frontend/inventory-frontend/src/components/ProductFilters/ProductFilters.tsx
+++ b/frontend/inventory-frontend/src/components/ProductFilters/ProductFilters.tsx
@@ -21,6 +21,17 @@ export default function ProductFilters({ onSearch, existingCategories }: Props) 
         })
     }
 
+    const handleClear = () => {
+        setName('')
+        setCategories([])
+        setAvailability('all')
+        onSearch({
+            name: '',
+            categories: [],
+            inStock: undefined,
+        })
+    }
+
     return (
     <Box
         component="form"
@@ -78,6 +89,9 @@ export default function ProductFilters({ onSearch, existingCategories }: Props) 
             Search
         </Button>
 
-        </Box>
+        <Button variant="outlined" color="primary" onClick={handleClear}>
+            Clear Filters
+        </Button>
+    </Box>
     )
 }


### PR DESCRIPTION
### Summary
Implemented a "Clear Filters" button in the product filtering section. The button resets all filter inputs:
- Name
- Category
- Availability

### Notes
- Resets the state to initial values.
- Triggers a fresh fetch of unfiltered product data.
- UI remains consistent with current design standards.