### PR TITLE
fix: reset product form when reopening the new product dialog

### DIFF
--- a/frontend/inventory-frontend/src/components/ProductForm/ProductForm.tsx
+++ b/frontend/inventory-frontend/src/components/ProductForm/ProductForm.tsx
@@ -39,30 +39,10 @@ export default function ProductFormDialog({
         outOfStock: false
     })
 
-    useEffect(() => {
-        if (product) {
-            setForm(product)
-        } else {
-            setForm({
-                id: 0,
-                name: '',
-                category: '',
-                stockQuantity: 0,
-                unitPrice: 0,
-                expirationDate: '',
-                outOfStock: false
-            })
-        }
-    }, [product])
+    const [customCategory, setCustomCategory] = useState('')
 
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const { name, value } = e.target
-        setForm((prev) => ({ ...prev, [name]: value }))
-    }
-
-        const handleSelectChange = (e: SelectChangeEvent<string>) => {
-        const { name, value } = e.target
-        if (!name) return
         setForm((prev) => ({ ...prev, [name]: value }))
     }
 
@@ -82,7 +62,22 @@ export default function ProductFormDialog({
         onSave(finalProduct)
     }
 
-    const [customCategory, setCustomCategory] = useState('')
+    useEffect(() => {
+        if (product) {
+            setForm(product)
+        } else {
+            setForm({
+                id: 0,
+                name: '',
+                category: '',
+                stockQuantity: 0,
+                unitPrice: 0,
+                expirationDate: '',
+                outOfStock: false
+            })
+            setCustomCategory('')
+        }
+    }, [product, open])
 
     return (
         <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">

--- a/frontend/inventory-frontend/src/pages/ProductListPage.tsx
+++ b/frontend/inventory-frontend/src/pages/ProductListPage.tsx
@@ -22,10 +22,10 @@ export default function ProductListPage() {
     const allCategories = [...new Set(products.map(p => p.category))]
     const [isFormOpen, setIsFormOpen] = useState(false)
     const [editingProduct, setEditingProduct] = useState<Product | undefined>(undefined)
-    const [sortBy1, setSortBy1] = useState<string | undefined>()
-    const [direction1, setDirection1] = useState<'asc' | 'desc' | undefined>()
-    const [sortBy2, setSortBy2] = useState<string | undefined>()
-    const [direction2, setDirection2] = useState<'asc' | 'desc' | undefined>()
+    const [sortBy1, setSortBy1] = useState<string | undefined>(undefined)
+    const [direction1, setDirection1] = useState<'asc' | 'desc' | undefined>(undefined)
+    const [sortBy2, setSortBy2] = useState<string | undefined>(undefined)
+    const [direction2, setDirection2] = useState<'asc' | 'desc' | undefined>(undefined)
 
 
     function handleDelete(id: number) {
@@ -202,7 +202,6 @@ export default function ProductListPage() {
                 direction1={direction1 || 'asc'}
                 sortBy2={sortBy2 || ''}
                 direction2={direction2 || 'asc'}
-                
                 onSortChange={(column) => {
                     if (sortBy1 === column) {
                         if (direction1 === 'asc') {
@@ -233,8 +232,8 @@ export default function ProductListPage() {
                         setDirection2('asc')
                     }
                 }}
-            />
-            
+                />
+
             <Stack spacing={2} alignItems="center" mt={4}>
             <Pagination
                 count={totalPages}


### PR DESCRIPTION
### Summary
Fixed an issue where the "New Product" dialog retained the previous input values after creating a product. Now, the form is properly reset every time the dialog is opened.

### Fixes
- Form fields no longer stay populated after closing and reopening.
- Ensures a clean form for every new product entry.